### PR TITLE
Create an option to not include the level attachment.

### DIFF
--- a/NLogToSlack.Tests/SlackTargetTests.cs
+++ b/NLogToSlack.Tests/SlackTargetTests.cs
@@ -17,6 +17,7 @@ namespace NLogToSlack.Tests
             slackTarget.Icon.Should().Be(null);
             slackTarget.Username.Should().Be(null);
             slackTarget.WebHookUrl.Should().Be(null);
+            slackTarget.ExcludeLevel.Should().BeFalse();
         }
 
         [TestMethod]
@@ -26,13 +27,15 @@ namespace NLogToSlack.Tests
             const string icon = ":ghost:";
             const string username = "NLogToSlack-${level}";
             const string webHookUrl = "http://slack.is.awesome.com";
+            const bool excludeLevel = true;
 
             var slackTarget = new TestableSlackTarget
             {
                 Channel = channel,
                 Icon = icon,
                 Username = username,
-                WebHookUrl = webHookUrl
+                WebHookUrl = webHookUrl,
+                ExcludeLevel = excludeLevel
             };
 
             var logEvent = new LogEventInfo { Level = LogLevel.Info, Message = "This is a ${level} message" };
@@ -41,6 +44,7 @@ namespace NLogToSlack.Tests
             slackTarget.Username.Render(logEvent).Should().Be("NLogToSlack-Info");
             slackTarget.Icon.Should().Be(icon);
             slackTarget.WebHookUrl.Should().Be(webHookUrl);
+            slackTarget.ExcludeLevel.Should().BeTrue();
 
 
         }

--- a/NLogToSlack/SlackTarget.cs
+++ b/NLogToSlack/SlackTarget.cs
@@ -23,7 +23,7 @@ namespace NLogToSlack
 
         public string Icon { get; set; }
 
-        public bool IncludeLevel { get; set; }
+        public bool ExcludeLevel { get; set; }
         
         protected override void InitializeTarget()
         {
@@ -84,7 +84,7 @@ namespace NLogToSlack
                 payload.Username = username;
             }
 
-            if (IncludeLevel)
+            if (!ExcludeLevel)
             {
                 var mainAttachment = new Attachment
                 {

--- a/NLogToSlack/SlackTarget.cs
+++ b/NLogToSlack/SlackTarget.cs
@@ -22,6 +22,8 @@ namespace NLogToSlack
         public SimpleLayout Username { get; set; }
 
         public string Icon { get; set; }
+
+        public bool IncludeLevel { get; set; }
         
         protected override void InitializeTarget()
         {
@@ -81,13 +83,16 @@ namespace NLogToSlack
             {
                 payload.Username = username;
             }
-            
-            var mainAttachment = new Attachment
+
+            if (IncludeLevel)
             {
-                Title = info.LogEvent.Level.ToString(),
-                Color = info.LogEvent.Level.ToSlackColor()
-            };
-            payload.Attachments.Add(mainAttachment);
+                var mainAttachment = new Attachment
+                {
+                    Title = info.LogEvent.Level.ToString(),
+                    Color = info.LogEvent.Level.ToSlackColor()
+                };
+                payload.Attachments.Add(mainAttachment);
+            }
             if (info.LogEvent.Parameters != null)
             {
                 foreach (var param in info.LogEvent.Parameters)


### PR DESCRIPTION
If the target has IncludeLevel=false then the main attachment is not included.
