### PR TITLE
Proxy Credentials - use Default Cache

### DIFF
--- a/NLogToSlack/Models/Payload.cs
+++ b/NLogToSlack/Models/Payload.cs
@@ -102,6 +102,7 @@ namespace NLogToSlack.Models
             {
                 client.Headers[HttpRequestHeader.ContentType] = "application/json";
                 client.Encoding = Encoding.UTF8;
+                client.Proxy.Credentials = CredentialCache.DefaultNetworkCredentials;
                 client.UploadString(webHookUrl, "POST", json);
             }
         }


### PR DESCRIPTION
Allow Proxy Credentials to be pulled from the Default Network
Credentials Cache. Allows posting to Slack whilst debugging in Visual
Studio on a private domain.
